### PR TITLE
Prefix nginx configuration files to get it parsed before anything

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -83,7 +83,8 @@ do
 
 # Nginx location block
 
-sudo cp ../conf/nginx.conf /etc/nginx/conf.d/$domain.d/$app.conf
+# 000- prefix is to be sure to get parsed before other files rules
+sudo cp ../conf/nginx.conf /etc/nginx/conf.d/$domain.d/000-$app.conf
 sudo service nginx restart
 
 # SSOwat unprotected regex

--- a/scripts/remove
+++ b/scripts/remove
@@ -30,7 +30,7 @@ certPath=/etc/yunohost/certs/
 for domain in $domains
 do
     # Backup nginx conf file
-    sudo mv /etc/nginx/conf.d/$domain.d/$app.conf $backupFolder/$domain.nginx
+    sudo mv /etc/nginx/conf.d/$domain.d/000-$app.conf $backupFolder/$domain.nginx
 
     # If a backup of self-signed cert exist
     if [ -d "$certPath/$domain.beforeLetsEncrypt" ]; then

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -1,3 +1,15 @@
 #!/bin/bash
 
-# Empty
+app=letsencrypt
+domains=$(sudo yunohost app setting $app installDomains)
+
+for domain in $domains
+do
+    # If using old nginx conf path (without prefix), migrate it
+    if [ -e  "/etc/nginx/conf.d/$domain.d/$app.conf" ]; then
+      sudo mv /etc/nginx/conf.d/$domain.d/$app.conf \
+              /etc/nginx/conf.d/$domain.d/000-$app.conf
+    fi
+done
+
+sudo service nginx reload


### PR DESCRIPTION
I had funny failling cases : app confs that were in lexicographic order before
"letsencrypt". The ACME challenge was not reachable for those.

That does not hurt all applications, but those who are at the root of the
domain (not in a subfolder) are impacted.

That patch gives better chances that the letsencrypt conf has priority over the
application itself, making acme challenge reachable.
